### PR TITLE
Add option to set exportFormat from Column builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,47 @@ You can format column by setting it via Column definition on you DataTable servi
 Column::make('mobile')->exportFormat('00000000000'),
 ```
 
+## Date Fields Formatting
+
+The package will auto-detect date fields when used with a valid format.
+
+```phpt
+Column::make('report_date')->exportFormat('mm/dd/yyyy'),
+Column::make('created_at'),
+Column::make('updated_at')->exportFormat(NumberFormat::FORMAT_DATE_DATETIME),
+```
+
+## Valid Date Formats
+
+Valid date formats can be adjust on `datatables-export.php` config file.
+
+```phpt
+    'date_formats' => [
+        'mm/dd/yyyy',
+        NumberFormat::FORMAT_DATE_DATETIME,
+        NumberFormat::FORMAT_DATE_YYYYMMDD,
+        NumberFormat::FORMAT_DATE_XLSX22,
+        NumberFormat::FORMAT_DATE_DDMMYYYY,
+        NumberFormat::FORMAT_DATE_DMMINUS,
+        NumberFormat::FORMAT_DATE_DMYMINUS,
+        NumberFormat::FORMAT_DATE_DMYSLASH,
+        NumberFormat::FORMAT_DATE_MYMINUS,
+        NumberFormat::FORMAT_DATE_TIME1,
+        NumberFormat::FORMAT_DATE_TIME2,
+        NumberFormat::FORMAT_DATE_TIME3,
+        NumberFormat::FORMAT_DATE_TIME4,
+        NumberFormat::FORMAT_DATE_TIME5,
+        NumberFormat::FORMAT_DATE_TIME6,
+        NumberFormat::FORMAT_DATE_TIME7,
+        NumberFormat::FORMAT_DATE_XLSX14,
+        NumberFormat::FORMAT_DATE_XLSX15,
+        NumberFormat::FORMAT_DATE_XLSX16,
+        NumberFormat::FORMAT_DATE_XLSX17,
+        NumberFormat::FORMAT_DATE_YYYYMMDD2,
+        NumberFormat::FORMAT_DATE_YYYYMMDDSLASH,
+    ]
+```
+
 The format above will treat mobile numbers with leading zeroes.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ You can format column by setting it via Column definition on you DataTable servi
 Column::make('mobile')->exportFormat('00000000000'),
 ```
 
+The format above will treat mobile numbers with leading zeroes.
+
 ## Date Fields Formatting
 
 The package will auto-detect date fields when used with a valid format.
@@ -134,8 +136,6 @@ Valid date formats can be adjust on `datatables-export.php` config file.
         NumberFormat::FORMAT_DATE_YYYYMMDDSLASH,
     ]
 ```
-
-The format above will treat mobile numbers with leading zeroes.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ You can set the export type by setting the property to `csv` or `xlsx`. Default 
 <livewire:export-button :table-id="$dataTable->getTableId()" type="csv" />
 ```
 
+## Formatting Columns
+
+You can format column by setting it via Column definition on you DataTable service class.
+
+```phpt
+Column::make('mobile')->exportFormat('00000000000'),
+```
+
+The format above will treat mobile numbers with leading zeroes.
 
 ## Contributing
 

--- a/src/Exports/DataTableQueuedExport.php
+++ b/src/Exports/DataTableQueuedExport.php
@@ -5,11 +5,13 @@ namespace Yajra\DataTables\Exports;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithColumnFormatting;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use Yajra\DataTables\Html\Column;
 
-class DataTableQueuedExport implements FromQuery, WithMapping, WithHeadings
+class DataTableQueuedExport implements FromQuery, WithMapping, WithHeadings, WithColumnFormatting
 {
     use Exportable;
 
@@ -39,5 +41,27 @@ class DataTableQueuedExport implements FromQuery, WithMapping, WithHeadings
     public function headings(): array
     {
         return $this->columns->pluck('title')->toArray();
+    }
+
+    public function columnFormats(): array
+    {
+        $formats = [];
+
+        $this->columns
+            ->each(function (Column $column, $index) use (&$formats) {
+                $formats[$this->num2alpha($index - 1)] = $column['exportFormat'] ?? NumberFormat::FORMAT_TEXT;
+            })
+            ->toArray();
+
+        return $formats;
+    }
+
+    protected function num2alpha($n)
+    {
+        for ($r = ""; $n >= 0; $n = intval($n / 26) - 1) {
+            $r = chr($n % 26 + 0x41) . $r;
+        }
+
+        return $r;
     }
 }

--- a/src/config/datatables-export.php
+++ b/src/config/datatables-export.php
@@ -1,3 +1,34 @@
 <?php
 
-return [];
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+
+return [
+
+    /**
+     * List of valid date formats to be used for auto-detection.
+     */
+    'date_formats' => [
+        'mm/dd/yyyy',
+        NumberFormat::FORMAT_DATE_DATETIME,
+        NumberFormat::FORMAT_DATE_YYYYMMDD,
+        NumberFormat::FORMAT_DATE_XLSX22,
+        NumberFormat::FORMAT_DATE_DDMMYYYY,
+        NumberFormat::FORMAT_DATE_DMMINUS,
+        NumberFormat::FORMAT_DATE_DMYMINUS,
+        NumberFormat::FORMAT_DATE_DMYSLASH,
+        NumberFormat::FORMAT_DATE_MYMINUS,
+        NumberFormat::FORMAT_DATE_TIME1,
+        NumberFormat::FORMAT_DATE_TIME2,
+        NumberFormat::FORMAT_DATE_TIME3,
+        NumberFormat::FORMAT_DATE_TIME4,
+        NumberFormat::FORMAT_DATE_TIME5,
+        NumberFormat::FORMAT_DATE_TIME6,
+        NumberFormat::FORMAT_DATE_TIME7,
+        NumberFormat::FORMAT_DATE_XLSX14,
+        NumberFormat::FORMAT_DATE_XLSX15,
+        NumberFormat::FORMAT_DATE_XLSX16,
+        NumberFormat::FORMAT_DATE_XLSX17,
+        NumberFormat::FORMAT_DATE_YYYYMMDD2,
+        NumberFormat::FORMAT_DATE_YYYYMMDDSLASH,
+    ]
+];


### PR DESCRIPTION
This PR will allow setting of Excel's column format via Column builder definition:

```php
Column::make('mobile')->exportFormat('00000000000'),
Column::make('total')->exportFormat(NumberFormat::FORMAT_CURRENCY_EUR_SIMPLE),
```

Ref: https://docs.laravel-excel.com/3.1/exports/column-formatting.html

The PR will also auto-detect date fields 😍 

```php
Column::make('report_date')->exportFormat('mm/dd/yyyy'),
Column::make('created_at'),
Column::make('updated_at')->exportFormat(NumberFormat::FORMAT_DATE_DATETIME),
```
