### PR TITLE
Migrate to OpenSpout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/yajra/laravel-datatables-export.svg)](https://packagist.org/packages/yajra/laravel-datatables-export)
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://packagist.org/packages/yajra/laravel-datatables-export)
 
-This package is a plugin of [Laravel DataTables](https://github.com/yajra/laravel-datatables) for handling server-side exporting using Queue, Spout and Livewire.
+This package is a plugin of [Laravel DataTables](https://github.com/yajra/laravel-datatables) for handling server-side exporting using Queue, OpenSpout and Livewire.
 
 ## Requirements
 
 - [PHP >=7.4](http://php.net/)
 - [Laravel 8+](https://github.com/laravel/framework)
 - [Laravel Livewire](https://laravel-livewire.com/)
-- [Spout](https://github.com/box/spout)
+- [OpenSpout](https://github.com/openspout/openspout)
 - [Laravel DataTables 9.x](https://github.com/yajra/laravel-datatables)
 - [jQuery DataTables v1.10.x](http://datatables.net/)
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "yajra/laravel-datatables-buttons": "4.*|9.*",
     "yajra/laravel-datatables-html": "^4.40|9.*",
     "livewire/livewire": "2.*|3.*",
-    "openspout/openspout": "^3"
+    "openspout/openspout": "^4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5.9"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "yajra/laravel-datatables-buttons": "4.*|9.*",
     "yajra/laravel-datatables-html": "^4.40|9.*",
     "livewire/livewire": "2.*|3.*",
-    "box/spout": "^3.3"
+    "openspout/openspout": "^3"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5.9"

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -2,10 +2,10 @@
 
 namespace Yajra\DataTables\Jobs;
 
-use Box\Spout\Common\Helper\CellTypeHelper;
-use Box\Spout\Common\Type;
-use Box\Spout\Writer\Common\Creator\Style\StyleBuilder;
-use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
+use OpenSpout\Common\Helper\CellTypeHelper;
+use OpenSpout\Common\Type;
+use OpenSpout\Writer\Common\Creator\Style\StyleBuilder;
+use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Carbon\Carbon;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -56,9 +56,9 @@ class DataTableExportJob implements ShouldQueue, ShouldBeUnique
      * Execute the job.
      *
      * @return void
-     * @throws \Box\Spout\Common\Exception\IOException
-     * @throws \Box\Spout\Common\Exception\UnsupportedTypeException
-     * @throws \Box\Spout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function handle()
     {


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-export/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
Due to [box/spout](https://github.com/box/spout) being abandoned, it is recommended to migrate to [OpenSpout](https://github.com/openspout/openspout) which is actively being developed and is a direct fork of box/spout. This PR followed the instructions of the [upgrade guide from box/spout:v3 to openspout/openspout:v3](https://github.com/openspout/openspout#upgrade-from-boxspoutv3-to-openspoutopenspoutv3).