### PR TITLE
Fix compatibility with PHP7.4 and DataTables v9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1]
+        php: [7.4, 8.0, 8.1]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "maatwebsite/excel": "^3.1.40",
     "nunomaduro/larastan": "^1.0|^2.1",
-    "orchestra/testbench": "^7.3"
+    "orchestra/testbench": "6.*|^7.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,7 @@
   "config": {
     "preferred-install": "dist",
     "sort-packages": true,
-    "optimize-autoloader": true,
-    "platform": {
-      "php": "8.0.2"
-    }
+    "optimize-autoloader": true
   },
   "extra": {
     "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "maatwebsite/excel": "^3.1.40",
-    "nunomaduro/larastan": "^2.1",
+    "nunomaduro/larastan": "^1.0|^2.1",
     "orchestra/testbench": "^7.3"
   },
   "autoload": {

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -40,21 +40,24 @@ class DataTableExportJob implements ShouldQueue, ShouldBeUnique
 
     public array $request;
 
-    public int $user;
+    /**
+     * @var int|string
+     */
+    public $user;
 
     /**
      * Create a new job instance.
      *
      * @param  array  $dataTable
      * @param  array  $request
-     * @param  ?int  $user
+     * @param  int|string  $user
      */
-    public function __construct(array $dataTable, array $request, ?int $user)
+    public function __construct(array $dataTable, array $request, $user)
     {
         $this->dataTable = $dataTable[0];
         $this->attributes = $dataTable[1];
         $this->request = $request;
-        $this->user = $user ?? 0;
+        $this->user = $user;
     }
 
     /**

--- a/src/WithExportQueue.php
+++ b/src/WithExportQueue.php
@@ -20,7 +20,7 @@ trait WithExportQueue
      *
      * @throws \Throwable
      */
-    public function render(string $view, array $data = [], array $mergeData = [])
+    public function render($view, $data = [], $mergeData = [])
     {
         if (request()->ajax() && request('action') == 'exportQueue') {
             return $this->exportQueue();

--- a/src/WithExportQueue.php
+++ b/src/WithExportQueue.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
 use Yajra\DataTables\Jobs\DataTableExportJob;
 
@@ -38,13 +39,13 @@ trait WithExportQueue
      */
     public function exportQueue(): string
     {
-        $batch = Bus::batch([
-            new DataTableExportJob(
-                [self::class, $this->attributes],
-                $this->request->all(),
-                optional($this->request->user())->id
-            ),
-        ])->name('datatables-export')->dispatch();
+        $job = new DataTableExportJob(
+            [self::class, $this->attributes],
+            request()->all(),
+            Auth::id() ?? 0
+        );
+
+        $batch = Bus::batch([$job])->name('datatables-export')->dispatch();
 
         return $batch->id;
     }


### PR DESCRIPTION
Fix php74 - DataTables v9 compatibility

## Error

```php
Declaration of Yajra\DataTables\WithExportQueue::render(string $view, array $data = Array, array $mergeData = Array) should be compatible with Yajra\DataTables\Services\DataTable::render($view, $data = Array, $mergeData = Array)
```