### PR TITLE
Fix export on columns from eloquent relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+## v0.13.1 - 08-04-2022
+
+- Fix export on columns from eloquent relation #29
+
 ## v0.13.0 - 08-04-2022
 
 - Performance improvement #27

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -126,12 +126,10 @@ class DataTableExportJob implements ShouldQueue, ShouldBeUnique
         foreach ($query as $row) {
             $cells = [];
 
-            if (! $row instanceof Model) {
-                $row = $row instanceof Arrayable ? $row->toArray() : (array) $row;
-            }
+            $row = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
             if ($this->usesLazyMethod() && is_array($row)) {
-                $row = Arr::flatten($row);
+                $row = Arr::dot($row);
             }
 
             $defaultDateFormat = strval(config('datatables-export.default_date_format', 'yyyy-mm-dd'));

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -245,7 +245,7 @@ class DataTableExportJob implements ShouldQueue, ShouldBeUnique
     }
 
     /**
-     * @param  mixed  $value
+     * @param  int|bool|string|null  $value
      * @return bool
      */
     protected function isNumeric($value): bool


### PR DESCRIPTION
This update will fix the issue on missing columns when the source column is from eloquent relations.

1. remove condition where $row is being checked if not Model
2. use the Array dot method instead of flattening.

