### PR TITLE
Updated `phpoffice/phpspreadsheet`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "livewire/livewire": "^2.11.2|^3.5.6",
         "openspout/openspout": "^4.24.5",
-        "phpoffice/phpspreadsheet": "2.2.1",
+        "phpoffice/phpspreadsheet": "2.3.0",
         "yajra/laravel-datatables-buttons": "^11.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi Arjay 👋 

During installation of laravel-datables, it found 5 security vulnerability advisories.
All were related to `phpoffice/phpspreadsheet`.

These issues were solved in `2.3.0`.

![Screenshot 2024-10-09 at 14 11 03](https://github.com/user-attachments/assets/5e297057-7645-443e-a8d1-fd65d07303c5)

👋  - Edwin