### PR TITLE
feat: Support exportRender option

### DIFF
--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -149,6 +149,11 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
                 /** @var array|bool|int|string|null|DateTimeInterface $value */
                 $value = $row[$property] ?? '';
 
+                if (isset($column->exportRender)) {
+                    $callback = $column->exportRender;
+                    $value = $callback($row, $value);
+                }
+
                 if (is_array($value)) {
                     $value = json_encode($value);
                 }


### PR DESCRIPTION
Closes https://github.com/yajra/laravel-datatables-export/issues/70

Support the `exportRender` option so we can for example use it like this:
```php
->exportRender(fn ($value) => trim($value))
```
