### PR TITLE
fix: allow phpoffice v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "livewire/livewire": "^2.11.2|^3.5.6",
         "openspout/openspout": "^4.24.5",
-        "phpoffice/phpspreadsheet": "^2.3.5",
+        "phpoffice/phpspreadsheet": "^1.29.9|^2.3.7",
         "yajra/laravel-datatables-buttons": "^11.0"
     },
     "require-dev": {


### PR DESCRIPTION
We are trying to migrate our project from another export lib to `yajra/laravel-datatables-export`, but we want to do it progressively.
Unfortunately, the other lib requires PHPOffice 1, and the latest version of `yajra/laravel-datatables-export` now requires PHPOffice 2 resulting in conflicts if we want to install the latest version of `yajra/laravel-datatables-export`.

Few weeks ago, the phpoffice lib was upgraded to v2 to fix a vulnerability issue: https://github.com/yajra/laravel-datatables-export/pull/63

All security patches are now backported to the v1 branch so I think it's safe to allow both v1 and v2.
Latest security patches I found:
- `1.29.9`: https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/1.29.9
- `2.3.7`: https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/2.3.7

I tested on my local environment and `1.29.9` is still working properly with `yajra/laravel-datatables-export`.