### PR TITLE
fix: replace export request

### DIFF
--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -76,7 +76,7 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
 
         /** @var DataTable $oTable */
         $oTable = resolve($this->dataTable);
-        request()->merge($this->request);
+        request()->replace($this->request);
 
         $query = app()->call([$oTable->with($this->attributes), 'query']);
 


### PR DESCRIPTION
We are facing a bug in our app with exports filtered by a custom search form.

Because the current code is using `->merge()`, the first export works well, but on the 2nd export, the previous request is kept in memory and previous params are merged with the new request.
If a praram has been removed in the new request, that param will not be removed from the request, resulting in incorrect filters applied to the query.