### PR TITLE
fix: Do not replace empty values by null

### DIFF
--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -141,7 +141,7 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
                 }
 
                 /** @var array|bool|int|string|null|DateTimeInterface $value */
-                $value = $this->getValue($row, $property) ?? '';
+                $value = $this->getValue($row, $property);
 
                 if (isset($column->exportRender)) {
                     $callback = $column->exportRender;


### PR DESCRIPTION
In our project we have a `nullable` column casted as `Enum` and we specified a custom export function to return:
```php
$data?->value
```

But because the export transform `null` values into empty string, this does not work.
We are supposed to get an Enum or null, but we receive a string.

`?? ''` was added [long time ago](https://github.com/yajra/laravel-datatables-export/commit/4f5001b462dd3383c8c445744edac7ca65dd8717) when data was retrieved with `$row->{$property}`.
Since this was refactored to use `data_get()` (inside `getValue()`), it is not required anymore.