### PR TITLE
Make queue configurable

### DIFF
--- a/src/WithExportQueue.php
+++ b/src/WithExportQueue.php
@@ -43,7 +43,10 @@ trait WithExportQueue
             $this->sheetName(),
         );
 
-        $batch = Bus::batch([$job])->name('datatables-export')->dispatch();
+        $batch = Bus::batch([$job])
+            ->name('datatables-export')
+            ->when(config('datatables-export.queue'), fn($batch, $queue) => $batch->onQueue($queue))
+            ->dispatch();
 
         return $batch->id;
     }

--- a/src/config/datatables-export.php
+++ b/src/config/datatables-export.php
@@ -106,4 +106,15 @@ return [
     'purge' => [
         'days' => 1,
     ],
+
+    /*
+     * --------------------------------------------------------------------------
+     * Export Queue Name
+     * --------------------------------------------------------------------------
+     *
+     * The name of the queue connection to use for processing the export batch jobs.
+     * If this is set to null, the jobs will be pushed to the application's default queue.
+     *
+     */
+    'queue' => env('DATATABLES_EXPORT_QUEUE', null),
 ];


### PR DESCRIPTION
Currently, when using WithExportQueue, the export batch jobs are dispatched to the application's default queue. In many applications, heavy export tasks are processed on a dedicated, isolated queue to prevent them from blocking standard application jobs like notifications or emails.

This PR introduces the ability to specify a dedicated queue for Datatables export batches via the configuration file.

Changes Made

Config: Added a queue option to config/datatables-export.php with a DATATABLES_EXPORT_QUEUE environment variable fallback.

Trait: Updated the WithExportQueue trait to apply the queue name to the PendingBatch using Laravel's fluent when() method, keeping the implementation clean.