### PR TITLE
Fix duplicated export styles

### DIFF
--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -58,6 +58,11 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
     public array $attributes = [];
 
     /**
+     * @var array<string, Style>
+     */
+    public array $formatStyles = [];
+
+    /**
      * @param  array{class-string<DataTable>, array}  $instance
      */
     public function __construct(
@@ -244,7 +249,7 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
             return null;
         }
 
-        return OpenSpoutExportStyle::forFormat($format);
+        return $this->formatStyles[$format] ??= OpenSpoutExportStyle::forFormat($format);
     }
 
     protected function getDisk(): string


### PR DESCRIPTION
OpenSpout is no longer merging styles in v5, resulting in duplicated styles declared in the generated excel file.
This is causing corrupted excel files when exporting large files because of too many styles declared.

See https://github.com/openspout/openspout/blob/5.x/UPGRADE.md#upgrading-from-4x-to-50

Seems related to https://github.com/openspout/openspout/issues/359

This PR fixes it by declaring styles only once and reusing them.