### PR TITLE
fix(deps): require patched phpspreadsheet

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,7 +27,7 @@ Composer will not resolve until your app matches these **peer-style** constraint
 | Package | Minimum constraint | Notes |
 |--------|-------------------|--------|
 | [Livewire](https://livewire.laravel.com/docs/upgrading) | **^4.0** | Livewire v2 and v3 are no longer supported by this package. Upgrade the app to Livewire 4 first. |
-| [PhpSpreadsheet](https://github.com/PHPOffice/PhpSpreadsheet) | **^5.0** | Used for `NumberFormat` constants in config and column `exportFormat` examples. PhpSpreadsheet 4.x and older are not installed alongside current releases. |
+| [PhpSpreadsheet](https://github.com/PHPOffice/PhpSpreadsheet) | **^5.8.1** | Used for `NumberFormat` constants in config and column `exportFormat` examples. Earlier 5.x releases are excluded because of known security vulnerabilities. |
 | [OpenSpout](https://github.com/openspout/openspout) | **^4.24.5** or **^5** | Used internally for queued export writing. **OpenSpout 4** supports PHP 8.3–8.5; **OpenSpout 5** requires PHP 8.4+. Composer picks a compatible major for your PHP version and the rest of the dependency graph. Pin `openspout/openspout` in your app if you need a specific line. |
 
 There is no application code migration for the Livewire export button beyond meeting Livewire 4’s upgrade steps in your app. Published Blade views under `resources/views/vendor/datatables-export` should be re-published or diffed after major Livewire upgrades.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "livewire/livewire": "^4.2.2",
         "openspout/openspout": "^4.24.5 || ^5.0",
-        "phpoffice/phpspreadsheet": "^5.5",
+        "phpoffice/phpspreadsheet": "^5.8.1",
         "yajra/laravel-datatables-buttons": "^13.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

- require PhpSpreadsheet `^5.8.1`
- document the secure minimum version in the v13 upgrade guide

## Why

PhpSpreadsheet versions through 5.8.0 are affected by CVE-2026-59931, allowing the `WEBSERVICE()` domain whitelist to be bypassed through HTTP redirects. Raising the minimum version prevents affected 5.x releases from being installed while preserving the existing `<6.0` compatibility boundary.

This also addresses the related PhpSpreadsheet advisories patched in 5.8.1.

## Impact

Applications updating this package will resolve PhpSpreadsheet 5.8.1 or newer within the 5.x release line.

## Verification

- `composer pr` (Rector, Pint, PHPStan, Pest)
- `composer validate --strict`
- `git diff --check`
- focused `composer audit` check reports no PhpSpreadsheet advisories

Fixes #96