### PR TITLE
feat: add non-livewire queued exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://packagist.org/packages/yajra/laravel-datatables-export)
 
 This package is a plugin of [Laravel DataTables](https://github.com/yajra/laravel-datatables) for handling server-side
-exporting using Queue, OpenSpout and Livewire.
+exporting using Queue and OpenSpout, with optional Livewire and DataTables button integrations.
 
 ## Requirements
 
 - [PHP >=8.3](http://php.net/) (OpenSpout 5.x, if installed, requires PHP 8.4+)
 - [Laravel 13](https://github.com/laravel/framework)
-- [Laravel Livewire](https://laravel-livewire.com/)
+- [Laravel Livewire](https://livewire.laravel.com/) (optional)
 - [OpenSpout](https://github.com/openspout/openspout/)
 - [Laravel DataTables 13.x](https://github.com/yajra/laravel-datatables)
 - [jQuery DataTables 2.x](http://datatables.net/)
@@ -54,6 +54,68 @@ php artisan vendor:publish --tag=datatables-export --force
 ```
 
 ## Usage
+
+### DataTables Button (No Livewire)
+
+Publish the package assets and include the queued export button script after jQuery, DataTables, and DataTables Buttons:
+
+```shell
+php artisan vendor:publish --tag=datatables-export
+```
+
+```html
+<script src="/vendor/datatables/dataTables.queuedExport.js"></script>
+```
+
+Add `WithExportQueue` to the DataTable service and configure the button with the existing HTML builder:
+
+```php
+use Yajra\DataTables\Html\Button;
+use Yajra\DataTables\Html\Builder as HtmlBuilder;
+use Yajra\DataTables\WithExportQueue;
+
+class UsersDataTable extends DataTable
+{
+    use WithExportQueue;
+
+    public function html(): HtmlBuilder
+    {
+        return $this->builder()
+            ->buttons([
+                Button::make([
+                    'extend' => 'queuedExport',
+                    'text' => 'Export Excel',
+                    'exportType' => 'xlsx',
+                    'filename' => 'users.xlsx',
+                    'sheetName' => 'Users',
+                    'autoDownload' => true,
+                ]),
+            ]);
+    }
+}
+```
+
+The button sends the table's current search, ordering, and filter parameters, displays export progress, polls the queued batch, and downloads the completed file. Supported options are `exportType`, `filename`, `sheetName`, `emailTo`, `autoDownload`, `pollInterval`, `processingText`, and `errorText`.
+
+JavaScript callbacks can be supplied as `onStart`, `onProgress`, `onSuccess`, and `onError`. The table element also dispatches `datatables-export:start`, `datatables-export:progress`, `datatables-export:success`, and `datatables-export:error` events:
+
+```js
+document.querySelector('#users-table').addEventListener('datatables-export:success', function (event) {
+    console.log(event.detail.export.download_url);
+});
+```
+
+Applications may listen for the server-side `ExportStarted`, `ExportCompleted`, and `ExportFailed` events to add notifications, broadcasting, or archival workflows. Broadcasting is optional and can use an application's own authenticated private channels.
+
+Status and download URLs use encrypted access tokens. Their lifetime defaults to 1,440 minutes and can be changed with the `token_ttl` option in `datatables-export.php`.
+
+### Livewire Button
+
+Install Livewire when using the Livewire component:
+
+```shell
+composer require livewire/livewire
+```
 
 1. Add the export-button livewire component on your view file that uses dataTable class.
 

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "livewire/livewire": "^4.2.2",
         "openspout/openspout": "^4.24.5 || ^5.0",
         "phpoffice/phpspreadsheet": "^5.8.1",
         "yajra/laravel-datatables-buttons": "^13.0.2"
     },
     "require-dev": {
         "larastan/larastan": "^3.9.3",
+        "livewire/livewire": "^4.2.2",
         "orchestra/testbench": "^11.0",
         "pestphp/pest": "^4.4.3",
         "pestphp/pest-plugin-laravel": "^4.1",
@@ -74,6 +74,9 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "suggest": {
+        "livewire/livewire": "Required only when using the Livewire export button."
+    },
     "funding": [
         {
             "type": "github",

--- a/src/Events/ExportCompleted.php
+++ b/src/Events/ExportCompleted.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yajra\DataTables\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Yajra\DataTables\Services\DataTable;
+
+class ExportCompleted
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  class-string<DataTable>  $dataTable
+     */
+    public function __construct(
+        public string $batchId,
+        public string $dataTable,
+        public int|string|null $user,
+        public string $type,
+        public string $disk,
+        public string $storedFilename,
+        public string $downloadFilename,
+    ) {}
+}

--- a/src/Events/ExportFailed.php
+++ b/src/Events/ExportFailed.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yajra\DataTables\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+use Yajra\DataTables\Services\DataTable;
+
+class ExportFailed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  class-string<DataTable>  $dataTable
+     */
+    public function __construct(
+        public string $batchId,
+        public string $dataTable,
+        public int|string|null $user,
+        public string $type,
+        public string $disk,
+        public string $storedFilename,
+        public string $downloadFilename,
+        public ?Throwable $exception,
+    ) {}
+}

--- a/src/Events/ExportStarted.php
+++ b/src/Events/ExportStarted.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yajra\DataTables\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Yajra\DataTables\Services\DataTable;
+
+class ExportStarted
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  class-string<DataTable>  $dataTable
+     */
+    public function __construct(
+        public string $batchId,
+        public string $dataTable,
+        public int|string|null $user,
+        public string $type,
+        public string $disk,
+        public string $storedFilename,
+        public string $downloadFilename,
+    ) {}
+}

--- a/src/ExportServiceProvider.php
+++ b/src/ExportServiceProvider.php
@@ -16,7 +16,9 @@ class ExportServiceProvider extends ServiceProvider
 
         $this->publishAssets();
 
-        Livewire::component('export-button', ExportButtonComponent::class);
+        if (class_exists(Livewire::class)) {
+            Livewire::component('export-button', ExportButtonComponent::class);
+        }
     }
 
     protected function publishAssets(): void
@@ -28,6 +30,10 @@ class ExportServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/resources/views' => base_path('/resources/views/vendor/datatables-export'),
         ], 'datatables-export');
+
+        $this->publishes([
+            __DIR__.'/resources/js/dataTables.queuedExport.js' => public_path('vendor/datatables/dataTables.queuedExport.js'),
+        ], 'datatables-export');
     }
 
     #[\Override]
@@ -37,6 +43,8 @@ class ExportServiceProvider extends ServiceProvider
 
         $this->commands([DataTablesPurgeExportCommand::class]);
 
-        $this->app->register(LivewireServiceProvider::class);
+        if (class_exists(LivewireServiceProvider::class)) {
+            $this->app->register(LivewireServiceProvider::class);
+        }
     }
 }

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -37,6 +37,10 @@ use OpenSpout\Writer\WriterInterface;
 use OpenSpout\Writer\XLSX\Helper\DateHelper;
 use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use Throwable;
+use Yajra\DataTables\Events\ExportCompleted;
+use Yajra\DataTables\Events\ExportFailed;
+use Yajra\DataTables\Events\ExportStarted;
 use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Services\DataTable;
@@ -69,7 +73,8 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
         array $instance,
         public array $request,
         public int|string|null $user,
-        public string $sheetName = 'Sheet1'
+        public string $sheetName = 'Sheet1',
+        public string $downloadFilename = '',
     ) {
         $this->dataTable = $instance[0];
         $this->attributes = $instance[1];
@@ -94,6 +99,20 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
         $oTable = resolve($this->dataTable);
         request()->replace($this->request);
 
+        $type = $this->getExportType();
+        $storedFilename = $this->getBatchId().'.'.$type;
+        $downloadFilename = $this->downloadFilename ?: $storedFilename;
+
+        Event::dispatch(new ExportStarted(
+            $this->getBatchId(),
+            $this->dataTable,
+            $this->user,
+            $type,
+            $this->getDownloadDisk(),
+            $storedFilename,
+            $downloadFilename,
+        ));
+
         $tableWithAttributes = $oTable->with($this->attributes);
         $queryCallable = [$tableWithAttributes, 'query'];
         if (! is_callable($queryCallable)) {
@@ -109,13 +128,7 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
         $dataTable = app()->call($dataTableCallable, compact('query'));
         $dataTable->skipPaging();
 
-        $type = 'xlsx';
-        $exportType = request('export_type', 'xlsx');
-        if (is_string($exportType)) {
-            $type = Str::of($exportType)->startsWith('csv') ? 'csv' : 'xlsx';
-        }
-
-        $filename = $this->batchId.'.'.$type;
+        $filename = $storedFilename;
 
         $path = Storage::disk($this->getDisk())->path($filename);
 
@@ -223,11 +236,38 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
             Storage::disk($this->getS3Disk())->putFileAs('', (new File($path)), $filename);
         }
 
-        $emailTo = request()->emailTo;
+        $emailTo = request('emailTo', request('email_to'));
         if ($emailTo && is_string($emailTo)) {
             $data = ['email' => urldecode($emailTo), 'path' => $path];
             $this->sendResults($data);
         }
+
+        Event::dispatch(new ExportCompleted(
+            $this->getBatchId(),
+            $this->dataTable,
+            $this->user,
+            $type,
+            $this->getDownloadDisk(),
+            $storedFilename,
+            $downloadFilename,
+        ));
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $type = $this->getExportType();
+        $storedFilename = $this->getBatchId().'.'.$type;
+
+        Event::dispatch(new ExportFailed(
+            $this->getBatchId(),
+            $this->dataTable,
+            $this->user,
+            $type,
+            $this->getDownloadDisk(),
+            $storedFilename,
+            $this->downloadFilename ?: $storedFilename,
+            $exception,
+        ));
     }
 
     /**
@@ -346,6 +386,23 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
         }
 
         return $disk;
+    }
+
+    protected function getDownloadDisk(): string
+    {
+        return $this->getS3Disk() ?: $this->getDisk();
+    }
+
+    protected function getExportType(): string
+    {
+        $exportType = $this->request['export_type'] ?? $this->request['exportType'] ?? 'xlsx';
+
+        return is_string($exportType) && Str::startsWith(Str::lower($exportType), 'csv') ? 'csv' : 'xlsx';
+    }
+
+    protected function getBatchId(): string
+    {
+        return is_string($this->batchId) ? $this->batchId : '';
     }
 
     public function sendResults(array $data): void

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -91,7 +91,7 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
      */
     public function handle(): void
     {
-        if ($this->user) {
+        if ($this->user !== null) {
             Event::forget(Login::class);
             Auth::loginUsingId($this->user);
         }

--- a/src/Jobs/DataTableExportJob.php
+++ b/src/Jobs/DataTableExportJob.php
@@ -45,6 +45,7 @@ use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Services\DataTable;
 use Yajra\DataTables\Support\OpenSpoutExportStyle;
+use Yajra\DataTables\Support\QueuedExportProgress;
 
 class DataTableExportJob implements ShouldBeUnique, ShouldQueue
 {
@@ -150,15 +151,21 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
 
         $writer->addRow(Row::fromValues($headers));
 
+        $filteredQuery = $dataTable->getFilteredQuery();
+        $totalRows = $dataTable->filteredCount();
+
         if ($this->usesLazyMethod()) {
             $chunkSize = 1_000;
             if (is_int(config('datatables-export.chunk'))) {
                 $chunkSize = config('datatables-export.chunk');
             }
-            $query = $dataTable->getFilteredQuery()->lazy($chunkSize);
+            $query = $filteredQuery->lazy($chunkSize);
         } else {
-            $query = $dataTable->getFilteredQuery()->cursor();
+            $query = $filteredQuery->cursor();
         }
+
+        $processedRows = 0;
+        $reportedProgress = 0;
 
         foreach ($query as $row) {
             $cells = [];
@@ -228,6 +235,14 @@ class DataTableExportJob implements ShouldBeUnique, ShouldQueue
             });
 
             $writer->addRow(new Row($cells));
+
+            $processedRows++;
+            if ($totalRows > 0) {
+                $progress = min(99, (int) floor(($processedRows / $totalRows) * 100));
+                if ($progress > $reportedProgress) {
+                    $reportedProgress = QueuedExportProgress::report($this->getBatchId(), $processedRows, $totalRows);
+                }
+            }
         }
 
         $writer->close();

--- a/src/Support/QueuedExportManager.php
+++ b/src/Support/QueuedExportManager.php
@@ -42,7 +42,7 @@ class QueuedExportManager
         $job = new DataTableExportJob(
             [$dataTable::class, $attributes],
             $parameters,
-            $user ?? 0,
+            $user,
             $sheetName,
             $downloadFilename,
         );
@@ -106,18 +106,21 @@ class QueuedExportManager
             $progress = max($progress, QueuedExportProgress::get($batch->id) ?? 0);
         }
 
+        $statusUrl = $request->url().'?'.http_build_query([
+            'action' => 'queuedExportStatus',
+            'export_token' => $token,
+        ], encoding_type: PHP_QUERY_RFC3986);
+        $downloadUrl = $request->url().'?'.http_build_query([
+            'action' => 'queuedExportDownload',
+            'export_token' => $token,
+        ], encoding_type: PHP_QUERY_RFC3986);
+
         return [
             'id' => $batch->id,
             'status' => $this->batchStatus($batch),
             'progress' => $progress,
-            'status_url' => $request->fullUrlWithQuery([
-                'action' => 'queuedExportStatus',
-                'export_token' => $token,
-            ]),
-            'download_url' => $request->fullUrlWithQuery([
-                'action' => 'queuedExportDownload',
-                'export_token' => $token,
-            ]),
+            'status_url' => $statusUrl,
+            'download_url' => $downloadUrl,
         ];
     }
 

--- a/src/Support/QueuedExportManager.php
+++ b/src/Support/QueuedExportManager.php
@@ -101,10 +101,15 @@ class QueuedExportManager
      */
     protected function payload(Batch $batch, Request $request, string $token): array
     {
+        $progress = $batch->progress();
+        if (! $batch->finished()) {
+            $progress = max($progress, QueuedExportProgress::get($batch->id) ?? 0);
+        }
+
         return [
             'id' => $batch->id,
             'status' => $this->batchStatus($batch),
-            'progress' => $batch->progress(),
+            'progress' => $progress,
             'status_url' => $request->fullUrlWithQuery([
                 'action' => 'queuedExportStatus',
                 'export_token' => $token,

--- a/src/Support/QueuedExportManager.php
+++ b/src/Support/QueuedExportManager.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yajra\DataTables\Support;
+
+use Illuminate\Bus\Batch;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use JsonException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Yajra\DataTables\Jobs\DataTableExportJob;
+use Yajra\DataTables\Services\DataTable;
+
+class QueuedExportManager
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     *
+     * @throws \Throwable
+     */
+    public function dispatch(
+        DataTable $dataTable,
+        array $attributes,
+        Request $request,
+        int|string|null $user,
+        string $sheetName,
+        ?string $downloadFilename = null,
+    ): Batch {
+        $type = $this->exportType($request);
+        $downloadFilename ??= $this->downloadFilename($request, $sheetName, $type);
+        $parameters = $request->all();
+        $parameters['export_type'] = $type;
+
+        $job = new DataTableExportJob(
+            [$dataTable::class, $attributes],
+            $parameters,
+            $user ?? 0,
+            $sheetName,
+            $downloadFilename,
+        );
+
+        return Bus::batch([$job])
+            ->name('datatables-export')
+            ->when(config('datatables-export.queue'), fn ($batch, $queue) => $batch->onQueue($queue))
+            ->dispatch();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     *
+     * @throws \Throwable
+     */
+    public function start(
+        DataTable $dataTable,
+        array $attributes,
+        Request $request,
+        int|string|null $user,
+        string $sheetName,
+    ): JsonResponse {
+        $type = $this->exportType($request);
+        $filename = $this->downloadFilename($request, $sheetName, $type);
+        $batch = $this->dispatch($dataTable, $attributes, $request, $user, $sheetName, $filename);
+        $token = $this->createToken($batch->id, $type, $filename, $user);
+
+        return response()->json($this->payload($batch, $request, $token), 202);
+    }
+
+    public function status(Request $request): JsonResponse
+    {
+        $token = $this->resolveToken($request);
+        $batch = Bus::findBatch($token['batch_id']);
+        abort_if($batch === null, 404);
+
+        return response()->json($this->payload($batch, $request, $request->string('export_token')->toString()));
+    }
+
+    public function download(Request $request): StreamedResponse
+    {
+        $token = $this->resolveToken($request);
+        $batch = Bus::findBatch($token['batch_id']);
+        abort_if($batch === null, 404);
+        abort_if($batch->failedJobs > 0 || ! $batch->finished(), 409, 'The export is not available for download.');
+
+        $storedFilename = $batch->id.'.'.$token['type'];
+        $disk = $token['disk'];
+        abort_unless(Storage::disk($disk)->exists($storedFilename), 404);
+
+        return Storage::disk($disk)->download($storedFilename, $token['filename']);
+    }
+
+    /**
+     * @return array{id: string, status: string, progress: int, status_url: string, download_url: string}
+     */
+    protected function payload(Batch $batch, Request $request, string $token): array
+    {
+        return [
+            'id' => $batch->id,
+            'status' => $this->batchStatus($batch),
+            'progress' => $batch->progress(),
+            'status_url' => $request->fullUrlWithQuery([
+                'action' => 'queuedExportStatus',
+                'export_token' => $token,
+            ]),
+            'download_url' => $request->fullUrlWithQuery([
+                'action' => 'queuedExportDownload',
+                'export_token' => $token,
+            ]),
+        ];
+    }
+
+    protected function batchStatus(Batch $batch): string
+    {
+        if ($batch->failedJobs > 0) {
+            return 'failed';
+        }
+
+        return $batch->finished() ? 'finished' : 'pending';
+    }
+
+    protected function exportType(Request $request): string
+    {
+        $type = $request->input('export_type', $request->input('exportType', 'xlsx'));
+
+        if (! is_string($type) || ! in_array(Str::lower($type), ['csv', 'xlsx'], true)) {
+            throw ValidationException::withMessages([
+                'export_type' => 'The export type must be csv or xlsx.',
+            ]);
+        }
+
+        return Str::lower($type);
+    }
+
+    protected function downloadFilename(Request $request, string $sheetName, string $type): string
+    {
+        $filename = $request->input('filename');
+        if (! is_string($filename) || trim($filename) === '') {
+            $filename = (Str::slug($sheetName) ?: 'export').'-'.now()->format('Ymd-His');
+        }
+
+        $filename = basename(str_replace('\\', '/', $filename));
+        $filename = preg_replace('/[^A-Za-z0-9._ -]/', '-', $filename) ?: 'export';
+        $filename = trim($filename, " .\t\n\r\0\x0B");
+        $filename = $filename !== '' ? $filename : 'export';
+
+        if (Str::endsWith(Str::lower($filename), ['.csv', '.xlsx'])) {
+            $filename = pathinfo($filename, PATHINFO_FILENAME);
+        }
+
+        return $filename.'.'.$type;
+    }
+
+    protected function createToken(string $batchId, string $type, string $filename, int|string|null $user): string
+    {
+        $ttl = config('datatables-export.token_ttl', 1440);
+        $minutes = is_numeric($ttl) ? max(1, (int) $ttl) : 1440;
+
+        $payload = json_encode([
+            'batch_id' => $batchId,
+            'type' => $type,
+            'filename' => $filename,
+            'disk' => $this->downloadDisk(),
+            'user' => $user,
+            'expires_at' => now()->addMinutes($minutes)->getTimestamp(),
+        ], JSON_THROW_ON_ERROR);
+
+        return Crypt::encryptString($payload);
+    }
+
+    /**
+     * @return array{batch_id: string, type: string, filename: string, disk: string, user: int|string|null, expires_at: int}
+     */
+    protected function resolveToken(Request $request): array
+    {
+        try {
+            $encrypted = $request->string('export_token')->toString();
+            abort_if($encrypted === '', 404);
+
+            $token = json_decode(Crypt::decryptString($encrypted), true, flags: JSON_THROW_ON_ERROR);
+        } catch (DecryptException|JsonException) {
+            abort(404);
+        }
+
+        abort_unless(is_array($token), 404);
+        abort_unless(
+            isset($token['batch_id'], $token['type'], $token['filename'], $token['disk'], $token['expires_at'])
+            && is_string($token['batch_id'])
+            && in_array($token['type'], ['csv', 'xlsx'], true)
+            && is_string($token['filename'])
+            && is_string($token['disk'])
+            && is_int($token['expires_at'])
+            && (! array_key_exists('user', $token)
+                || is_int($token['user'])
+                || is_string($token['user'])
+                || $token['user'] === null),
+            404,
+        );
+        abort_if($token['expires_at'] < now()->getTimestamp(), 404);
+
+        $tokenUser = $token['user'] ?? null;
+        if ($tokenUser !== null) {
+            abort_unless(is_int($tokenUser) || is_string($tokenUser), 404);
+            $authenticatedUser = Auth::id();
+            abort_unless(is_int($authenticatedUser) || is_string($authenticatedUser), 404);
+            abort_unless(hash_equals((string) $tokenUser, (string) $authenticatedUser), 404);
+        }
+
+        /** @var array{batch_id: string, type: string, filename: string, disk: string, user: int|string|null, expires_at: int} $token */
+        return $token;
+    }
+
+    protected function downloadDisk(): string
+    {
+        $s3Disk = config('datatables-export.s3_disk');
+        if (is_string($s3Disk) && $s3Disk !== '') {
+            return $s3Disk;
+        }
+
+        $disk = config('datatables-export.disk', 'local');
+
+        return is_string($disk) ? $disk : 'local';
+    }
+}

--- a/src/Support/QueuedExportProgress.php
+++ b/src/Support/QueuedExportProgress.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yajra\DataTables\Support;
+
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+class QueuedExportProgress
+{
+    public static function get(string $batchId): ?int
+    {
+        try {
+            $progress = Cache::get(self::key($batchId));
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_int($progress) ? max(0, min(99, $progress)) : null;
+    }
+
+    public static function report(string $batchId, int $processedRows, int $totalRows): int
+    {
+        if ($batchId === '' || $totalRows < 1) {
+            return 0;
+        }
+
+        $progress = min(99, (int) floor(($processedRows / $totalRows) * 100));
+
+        try {
+            Cache::put(self::key($batchId), $progress, now()->addMinutes(self::ttl()));
+        } catch (Throwable) {
+            // Progress reporting must not fail the export when the cache is unavailable.
+        }
+
+        return $progress;
+    }
+
+    protected static function key(string $batchId): string
+    {
+        return 'datatables-export:'.$batchId.':progress';
+    }
+
+    protected static function ttl(): int
+    {
+        $ttl = config('datatables-export.token_ttl', 1440);
+
+        return is_numeric($ttl) ? max(1, (int) $ttl) : 1440;
+    }
+}

--- a/src/WithExportQueue.php
+++ b/src/WithExportQueue.php
@@ -24,7 +24,7 @@ trait WithExportQueue
     {
         $action = request('action');
 
-        if ($action === 'queuedExportStart') {
+        if (request()->ajax() && $action === 'queuedExportStart') {
             return $this->queuedExportStart();
         }
 

--- a/src/WithExportQueue.php
+++ b/src/WithExportQueue.php
@@ -2,10 +2,11 @@
 
 namespace Yajra\DataTables;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Bus;
-use Yajra\DataTables\Jobs\DataTableExportJob;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Yajra\DataTables\Services\DataTable;
+use Yajra\DataTables\Support\QueuedExportManager;
 
 /**
  * @mixin DataTable
@@ -21,7 +22,21 @@ trait WithExportQueue
      */
     public function render(?string $view = null, array $data = [], array $mergeData = [])
     {
-        if (request()->ajax() && request('action') == 'exportQueue') {
+        $action = request('action');
+
+        if ($action === 'queuedExportStart') {
+            return $this->queuedExportStart();
+        }
+
+        if ($action === 'queuedExportStatus') {
+            return $this->queuedExportStatus();
+        }
+
+        if ($action === 'queuedExportDownload') {
+            return $this->queuedExportDownload();
+        }
+
+        if (request()->ajax() && $action === 'exportQueue') {
             return $this->exportQueue();
         }
 
@@ -36,19 +51,41 @@ trait WithExportQueue
      */
     public function exportQueue(): string
     {
-        $job = new DataTableExportJob(
-            [$this::class, $this->attributes],
-            request()->all(),
-            Auth::id() ?? 0,
+        $batch = $this->exportManager()->dispatch(
+            $this,
+            $this->attributes,
+            request(),
+            Auth::id(),
             $this->sheetName(),
         );
 
-        $batch = Bus::batch([$job])
-            ->name('datatables-export')
-            ->when(config('datatables-export.queue'), fn ($batch, $queue) => $batch->onQueue($queue))
-            ->dispatch();
-
         return $batch->id;
+    }
+
+    /**
+     * Start a queued export using the JSON protocol.
+     *
+     * @throws \Throwable
+     */
+    public function queuedExportStart(): JsonResponse
+    {
+        return $this->exportManager()->start(
+            $this,
+            $this->attributes,
+            request(),
+            Auth::id(),
+            $this->sheetName(),
+        );
+    }
+
+    public function queuedExportStatus(): JsonResponse
+    {
+        return $this->exportManager()->status(request());
+    }
+
+    public function queuedExportDownload(): StreamedResponse
+    {
+        return $this->exportManager()->download(request());
     }
 
     /**
@@ -57,6 +94,13 @@ trait WithExportQueue
      */
     protected function sheetName(): string
     {
-        return request('sheetName', 'Sheet1');
+        $sheetName = request('sheetName', request('sheet_name', 'Sheet1'));
+
+        return is_string($sheetName) ? $sheetName : 'Sheet1';
+    }
+
+    protected function exportManager(): QueuedExportManager
+    {
+        return resolve(QueuedExportManager::class);
     }
 }

--- a/src/config/datatables-export.php
+++ b/src/config/datatables-export.php
@@ -117,4 +117,14 @@ return [
      *
      */
     'queue' => env('DATATABLES_EXPORT_QUEUE', null),
+
+    /*
+     * --------------------------------------------------------------------------
+     * Access Token Lifetime
+     * --------------------------------------------------------------------------
+     *
+     * Number of minutes that queued export status and download links remain valid.
+     *
+     */
+    'token_ttl' => 1440,
 ];

--- a/src/resources/js/dataTables.queuedExport.js
+++ b/src/resources/js/dataTables.queuedExport.js
@@ -1,0 +1,131 @@
+(function ($, DataTable) {
+    'use strict';
+
+    function emit(dt, name, detail) {
+        var table = dt.table().node();
+
+        if (typeof window.CustomEvent === 'function') {
+            table.dispatchEvent(new CustomEvent('datatables-export:' + name, {
+                bubbles: true,
+                detail: detail
+            }));
+        }
+    }
+
+    function callback(config, name, dt, payload) {
+        if (typeof config[name] === 'function') {
+            config[name](dt, payload, config);
+        }
+    }
+
+    function buildStartUrl(dt, config) {
+        var url = new URL(dt.ajax.url() || window.location.href, window.location.href);
+        var tableParams = new URLSearchParams($.param(dt.ajax.params()));
+
+        tableParams.forEach(function (value, key) {
+            url.searchParams.append(key, value);
+        });
+
+        url.searchParams.set('action', 'queuedExportStart');
+        url.searchParams.set('exportType', config.exportType || 'xlsx');
+        url.searchParams.set('sheetName', config.sheetName || 'Sheet1');
+
+        if (config.filename) {
+            url.searchParams.set('filename', config.filename);
+        }
+
+        if (config.emailTo) {
+            url.searchParams.set('emailTo', config.emailTo);
+        }
+
+        return url.toString();
+    }
+
+    function request(url) {
+        return $.ajax({
+            dataType: 'json',
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            method: 'GET',
+            url: url
+        });
+    }
+
+    DataTable.ext.buttons.queuedExport = {
+        autoDownload: true,
+        className: 'buttons-queued-export',
+        errorText: 'Export failed',
+        exportType: 'xlsx',
+        pollInterval: 2000,
+        processingText: 'Exporting…',
+        sheetName: 'Sheet1',
+
+        text: function (dt) {
+            return dt.i18n('buttons.queuedExport', 'Export');
+        },
+
+        action: function (e, dt, button, config) {
+            if (config._exporting) {
+                return;
+            }
+
+            window.clearTimeout(config._resetTimer);
+            config._exporting = true;
+            config._originalText = config._originalText || dt.button(button).text();
+            dt.button(button).enable(false);
+            dt.button(button).text(dt.i18n('buttons.queuedExportProcessing', config.processingText));
+
+            var finish = function () {
+                config._exporting = false;
+                dt.button(button).enable(true);
+                dt.button(button).text(config._originalText);
+            };
+
+            var fail = function (error) {
+                finish();
+                dt.button(button).text(dt.i18n('buttons.queuedExportError', config.errorText));
+                config._resetTimer = window.setTimeout(function () {
+                    dt.button(button).text(config._originalText);
+                }, 3000);
+                callback(config, 'onError', dt, error);
+                emit(dt, 'error', {error: error, config: config});
+            };
+
+            var succeed = function (payload) {
+                finish();
+                callback(config, 'onSuccess', dt, payload);
+                emit(dt, 'success', {export: payload, config: config});
+
+                if (config.autoDownload !== false) {
+                    window.location.assign(payload.download_url);
+                }
+            };
+
+            var observe = function (payload) {
+                var processingText = dt.i18n('buttons.queuedExportProcessing', config.processingText);
+                dt.button(button).text(processingText + ' ' + payload.progress + '%');
+                callback(config, 'onProgress', dt, payload);
+                emit(dt, 'progress', {export: payload, config: config});
+
+                if (payload.status === 'finished') {
+                    succeed(payload);
+                    return;
+                }
+
+                if (payload.status === 'failed') {
+                    fail(payload);
+                    return;
+                }
+
+                window.setTimeout(function () {
+                    request(payload.status_url).done(observe).fail(fail);
+                }, Math.max(250, Number(config.pollInterval) || 2000));
+            };
+
+            request(buildStartUrl(dt, config)).done(function (payload) {
+                callback(config, 'onStart', dt, payload);
+                emit(dt, 'start', {export: payload, config: config});
+                observe(payload);
+            }).fail(fail);
+        }
+    };
+})(jQuery, jQuery.fn.dataTable);

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -1,10 +1,164 @@
 <?php
 
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Yajra\DataTables\Events\ExportCompleted;
+use Yajra\DataTables\Events\ExportFailed;
+use Yajra\DataTables\Events\ExportStarted;
+use Yajra\DataTables\Exports\Tests\DataTables\UsersDataTable;
+use Yajra\DataTables\Exports\Tests\Models\User;
+use Yajra\DataTables\Jobs\DataTableExportJob;
+
+beforeEach(function () {
+    Storage::fake('local');
+});
 
 test('it can export to excel', function () {
     $this->get('/users')->assertOk();
     $batchId = $this->getAjax('/users?action=exportQueue')->getContent();
 
     $this->assertTrue(DB::table('job_batches')->where('id', $batchId)->exists());
+    Storage::disk('local')->assertExists($batchId.'.xlsx');
+});
+
+test('it starts observes and downloads an export without livewire', function () {
+    Event::fake([ExportStarted::class, ExportCompleted::class, ExportFailed::class]);
+
+    $response = $this->getAjax('/users?action=queuedExportStart&exportType=xlsx&filename=quarterly-report.xlsx');
+
+    $response->assertAccepted()
+        ->assertJsonPath('status', 'finished')
+        ->assertJsonPath('progress', 100);
+
+    $batchId = $response->json('id');
+    expect($batchId)->toBeString();
+    Storage::disk('local')->assertExists($batchId.'.xlsx');
+
+    Event::assertDispatched(ExportStarted::class, fn (ExportStarted $event) => $event->batchId === $batchId);
+    Event::assertDispatched(ExportCompleted::class, fn (ExportCompleted $event) => $event->downloadFilename === 'quarterly-report.xlsx');
+    Event::assertNotDispatched(ExportFailed::class);
+
+    $this->getJson($response->json('status_url'))
+        ->assertOk()
+        ->assertJsonPath('id', $batchId)
+        ->assertJsonPath('status', 'finished')
+        ->assertJsonPath('progress', 100);
+
+    $this->get($response->json('download_url'))
+        ->assertOk()
+        ->assertDownload('quarterly-report.xlsx');
+});
+
+test('it supports csv exports and sanitizes download filenames', function () {
+    $response = $this->getAjax('/users?action=queuedExportStart&export_type=csv&filename=../../unsafe%22.xlsx');
+
+    $response->assertAccepted();
+    Storage::disk('local')->assertExists($response->json('id').'.csv');
+
+    $this->get($response->json('download_url'))
+        ->assertOk()
+        ->assertDownload('unsafe-.csv');
+});
+
+test('it exposes pending and failed batch states', function () {
+    $response = $this->getAjax('/users?action=queuedExportStart');
+    $batchId = $response->json('id');
+
+    DB::table('job_batches')->where('id', $batchId)->update([
+        'pending_jobs' => 1,
+        'finished_at' => null,
+    ]);
+
+    $this->getJson($response->json('status_url'))
+        ->assertOk()
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('progress', 0);
+    $this->get($response->json('download_url'))->assertConflict();
+
+    DB::table('job_batches')->where('id', $batchId)->update([
+        'pending_jobs' => 0,
+        'failed_jobs' => 1,
+        'failed_job_ids' => json_encode(['failed-job']),
+    ]);
+
+    $this->getJson($response->json('status_url'))
+        ->assertOk()
+        ->assertJsonPath('status', 'failed');
+});
+
+test('it rejects invalid missing expired and cross-user access tokens', function () {
+    $this->getJson('/users?action=queuedExportStatus&export_token=invalid')->assertNotFound();
+
+    config()->set('datatables-export.token_ttl', 1);
+    $guestExport = $this->getAjax('/users?action=queuedExportStart');
+    $this->travel(2)->minutes();
+    $this->getJson($guestExport->json('status_url'))->assertNotFound();
+    $this->travelBack();
+
+    $owner = User::query()->firstOrFail();
+    $otherUser = User::query()->whereKeyNot($owner->getKey())->firstOrFail();
+    $this->actingAs($owner);
+    $ownedExport = $this->getAjax('/users?action=queuedExportStart');
+    $this->getJson($ownedExport->json('status_url'))->assertOk();
+
+    $this->actingAs($otherUser);
+    $this->getJson($ownedExport->json('status_url'))->assertNotFound();
+    $this->get($ownedExport->json('download_url'))->assertNotFound();
+});
+
+test('it returns not found when a completed export file is missing', function () {
+    $response = $this->getAjax('/users?action=queuedExportStart');
+    Storage::disk('local')->delete($response->json('id').'.xlsx');
+
+    $this->get($response->json('download_url'))->assertNotFound();
+});
+
+test('it validates the requested export type', function () {
+    $this->getAjax('/users?action=queuedExportStart&exportType=pdf')
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('export_type');
+});
+
+test('it passes table parameters and queue configuration to the export job', function () {
+    Bus::fake();
+    config()->set('datatables-export.queue', 'exports');
+
+    $this->getAjax('/users?action=queuedExportStart&exportType=csv&search[value]=Taylor')->assertAccepted();
+
+    Bus::assertBatched(function (PendingBatch $batch) {
+        if ($batch->queue() !== 'exports') {
+            return false;
+        }
+
+        $job = $batch->jobs->first();
+
+        return $job instanceof DataTableExportJob
+            && $job->dataTable === UsersDataTable::class
+            && $job->request['export_type'] === 'csv'
+            && $job->request['search']['value'] === 'Taylor';
+    });
+});
+
+test('it dispatches an export failed event with useful context', function () {
+    Event::fake([ExportFailed::class]);
+    $exception = new RuntimeException('Export failed.');
+    $job = new DataTableExportJob(
+        [UsersDataTable::class, []],
+        ['export_type' => 'csv'],
+        42,
+        'Users',
+        'users.csv',
+    );
+    $job->withBatchId('batch-id');
+
+    $job->failed($exception);
+
+    Event::assertDispatched(ExportFailed::class, fn (ExportFailed $event) => $event->batchId === 'batch-id'
+        && $event->user === 42
+        && $event->type === 'csv'
+        && $event->downloadFilename === 'users.csv'
+        && $event->exception === $exception);
 });

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -11,6 +11,7 @@ use Yajra\DataTables\Events\ExportStarted;
 use Yajra\DataTables\Exports\Tests\DataTables\UsersDataTable;
 use Yajra\DataTables\Exports\Tests\Models\User;
 use Yajra\DataTables\Jobs\DataTableExportJob;
+use Yajra\DataTables\Support\QueuedExportProgress;
 
 beforeEach(function () {
     Storage::fake('local');
@@ -35,6 +36,7 @@ test('it starts observes and downloads an export without livewire', function () 
 
     $batchId = $response->json('id');
     expect($batchId)->toBeString();
+    expect(QueuedExportProgress::get($batchId))->toBe(99);
     Storage::disk('local')->assertExists($batchId.'.xlsx');
 
     Event::assertDispatched(ExportStarted::class, fn (ExportStarted $event) => $event->batchId === $batchId);
@@ -67,6 +69,8 @@ test('it exposes pending and failed batch states', function () {
     $response = $this->getAjax('/users?action=queuedExportStart');
     $batchId = $response->json('id');
 
+    QueuedExportProgress::report($batchId, 10, 20);
+
     DB::table('job_batches')->where('id', $batchId)->update([
         'pending_jobs' => 1,
         'finished_at' => null,
@@ -75,7 +79,7 @@ test('it exposes pending and failed batch states', function () {
     $this->getJson($response->json('status_url'))
         ->assertOk()
         ->assertJsonPath('status', 'pending')
-        ->assertJsonPath('progress', 0);
+        ->assertJsonPath('progress', 50);
     $this->get($response->json('download_url'))->assertConflict();
 
     DB::table('job_batches')->where('id', $batchId)->update([

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -25,7 +25,7 @@ test('it can export to excel', function () {
     Storage::disk('local')->assertExists($batchId.'.xlsx');
 });
 
-test('it starts observes and downloads an export without livewire', function () {
+test('it starts, observes, and downloads an export without Livewire', function () {
     Event::fake([ExportStarted::class, ExportCompleted::class, ExportFailed::class]);
 
     $response = $this->getAjax('/users?action=queuedExportStart&exportType=xlsx&filename=quarterly-report.xlsx');
@@ -39,7 +39,8 @@ test('it starts observes and downloads an export without livewire', function () 
     expect(QueuedExportProgress::get($batchId))->toBe(99);
     Storage::disk('local')->assertExists($batchId.'.xlsx');
 
-    Event::assertDispatched(ExportStarted::class, fn (ExportStarted $event) => $event->batchId === $batchId);
+    Event::assertDispatched(ExportStarted::class, fn (ExportStarted $event) => $event->batchId === $batchId
+        && $event->user === null);
     Event::assertDispatched(ExportCompleted::class, fn (ExportCompleted $event) => $event->downloadFilename === 'quarterly-report.xlsx');
     Event::assertNotDispatched(ExportFailed::class);
 
@@ -52,6 +53,26 @@ test('it starts observes and downloads an export without livewire', function () 
     $this->get($response->json('download_url'))
         ->assertOk()
         ->assertDownload('quarterly-report.xlsx');
+});
+
+test('it only starts queued exports from ajax requests', function () {
+    Bus::fake();
+
+    $this->get('/users?action=queuedExportStart')->assertOk();
+
+    Bus::assertNothingBatched();
+});
+
+test('it returns minimal status and download urls', function () {
+    $response = $this->getAjax('/users?action=queuedExportStart&exportType=xlsx&search[value]=Taylor');
+
+    foreach (['status_url' => 'queuedExportStatus', 'download_url' => 'queuedExportDownload'] as $key => $action) {
+        parse_str((string) parse_url((string) $response->json($key), PHP_URL_QUERY), $query);
+
+        expect($query)->toHaveKeys(['action', 'export_token'])
+            ->and($query)->toHaveCount(2)
+            ->and($query['action'])->toBe($action);
+    }
 });
 
 test('it supports csv exports and sanitizes download filenames', function () {
@@ -141,6 +162,7 @@ test('it passes table parameters and queue configuration to the export job', fun
 
         return $job instanceof DataTableExportJob
             && $job->dataTable === UsersDataTable::class
+            && $job->user === null
             && $job->request['export_type'] === 'csv'
             && $job->request['search']['value'] === 'Taylor';
     });

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -2,9 +2,9 @@
 
 namespace Yajra\DataTables\Exports\Tests\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Model
+class User extends Authenticatable
 {
     protected $guarded = [];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -97,7 +97,13 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getEnvironmentSetUp($app): void
     {
+        $app['config']->set('app.key', 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
         $app['config']->set('app.debug', true);
+        $app['config']->set('auth.defaults.guard', 'web');
+        $app['config']->set('auth.providers.users', [
+            'driver' => 'eloquent',
+            'model' => User::class,
+        ]);
         $app['config']->set('queue.default', 'sync');
         $app['config']->set('database.default', 'sqlite');
         $app['config']->set('database.connections.sqlite', [


### PR DESCRIPTION
## Summary

- add a first-class `queuedExport` DataTables button with progress polling, auto-download, callbacks, and DOM events
- add encrypted, expiring status and download URLs backed by Laravel job batches
- add `ExportStarted`, `ExportCompleted`, and `ExportFailed` lifecycle events for application-level integrations
- make Livewire optional while preserving the existing `exportQueue` response and Livewire component
- document the non-Livewire integration and add coverage for compatibility, authorization, failures, validation, and downloads

## Why

Issue #55 requests an export experience that does not require Livewire. The existing backend already used Laravel job batches, but the raw batch ID and polling/download behavior were coupled to the Livewire component. This introduces a reusable transport and a packaged DataTables button without requiring broadcasting infrastructure.

## Developer impact

Applications can publish `dataTables.queuedExport.js`, configure `Button::make(['extend' => 'queuedExport'])`, and use the current DataTable route without adding new routes or dependencies. Existing Livewire consumers remain compatible. Status and download access is protected by encrypted tokens that expire and are bound to the initiating authenticated user when applicable.

## Validation

- `composer pr` (Rector, Pint, PHPStan, Pest: 9 tests / 39 assertions)
- `node --check src/resources/js/dataTables.queuedExport.js`
- `composer validate --strict`
- `git diff --check`

Closes #55