### PR TITLE
fix(export): reuse data table filename

### DIFF
--- a/src/Support/QueuedExportManager.php
+++ b/src/Support/QueuedExportManager.php
@@ -35,7 +35,7 @@ class QueuedExportManager
         ?string $downloadFilename = null,
     ): Batch {
         $type = $this->exportType($request);
-        $downloadFilename ??= $this->downloadFilename($request, $sheetName, $type);
+        $downloadFilename ??= $this->downloadFilename($dataTable, $request, $type);
         $parameters = $request->all();
         $parameters['export_type'] = $type;
 
@@ -66,7 +66,7 @@ class QueuedExportManager
         string $sheetName,
     ): JsonResponse {
         $type = $this->exportType($request);
-        $filename = $this->downloadFilename($request, $sheetName, $type);
+        $filename = $this->downloadFilename($dataTable, $request, $type);
         $batch = $this->dispatch($dataTable, $attributes, $request, $user, $sheetName, $filename);
         $token = $this->createToken($batch->id, $type, $filename, $user);
 
@@ -146,11 +146,11 @@ class QueuedExportManager
         return Str::lower($type);
     }
 
-    protected function downloadFilename(Request $request, string $sheetName, string $type): string
+    protected function downloadFilename(DataTable $dataTable, Request $request, string $type): string
     {
         $filename = $request->input('filename');
         if (! is_string($filename) || trim($filename) === '') {
-            $filename = (Str::slug($sheetName) ?: 'export').'-'.now()->format('Ymd-His');
+            $filename = $dataTable->getFilename();
         }
 
         $filename = basename(str_replace('\\', '/', $filename));

--- a/tests/DataTables/UsersDataTable.php
+++ b/tests/DataTables/UsersDataTable.php
@@ -41,4 +41,10 @@ class UsersDataTable extends DataTable
                 Column::make('email'),
             ]);
     }
+
+    #[\Override]
+    protected function filename(): string
+    {
+        return 'users-export';
+    }
 }

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -55,6 +55,14 @@ test('it starts, observes, and downloads an export without Livewire', function (
         ->assertDownload('quarterly-report.xlsx');
 });
 
+test('it uses the data table filename when no filename is requested', function () {
+    $response = $this->getAjax('/users?action=queuedExportStart&exportType=csv');
+
+    $this->get($response->json('download_url'))
+        ->assertOk()
+        ->assertDownload('users-export.csv');
+});
+
 test('it only starts queued exports from ajax requests', function () {
     Bus::fake();
 


### PR DESCRIPTION
## Summary

- use `DataTable::getFilename()` when a queued export request does not provide a filename
- preserve request-level filenames as explicit overrides
- keep the existing filename sanitization and requested export extension handling
- add regression coverage for DataTable filename overrides

## Root cause

The non-Livewire queued export flow introduced in #98 generated its own filename from the sheet name and timestamp. That bypassed the filename behavior already provided by `yajra/laravel-datatables-buttons`, including custom `filename()` implementations and values configured through `setFilename()`.

## Developer impact

Existing DataTable filename configuration is now honored by queued exports. Consumers that explicitly pass the queued export `filename` option retain the current behavior.

## Validation

- `composer pr` (Rector, Pint, PHPStan, Pest: 12 tests / 52 assertions)
- `composer validate --strict`
- `node --check src/resources/js/dataTables.queuedExport.js`
- `git diff --check`

Closes #99